### PR TITLE
fix: remove nodemon config

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,0 @@
-{
-  "events": {
-    "restart": "npm-run-all forestadmin:update-typings"
-  }
-}


### PR DESCRIPTION
> issue: CU-86c5a1jqr

Cloud-customizer should not update-typings from production as we save on local development. Locally running agent is now responsible of keeping the typings file up to date.